### PR TITLE
Allow deployment even if the destination server certificate is untrusted

### DIFF
--- a/WAWSDeploy/DeploymentArgs.cs
+++ b/WAWSDeploy/DeploymentArgs.cs
@@ -27,5 +27,13 @@ namespace WAWSDeploy
         /// <value>The password.</value>
         [ArgsMemberSwitch("p", "password", "pw")]
         public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the allowUntrusted flag
+        /// </summary>
+        /// <value>true or false</value>
+        [ArgsMemberSwitch("u", "allowuntrusted", "au")]
+        public bool AllowUntrusted { get; set; }
+
     }
 }

--- a/WAWSDeploy/Program.cs
+++ b/WAWSDeploy/Program.cs
@@ -12,6 +12,7 @@ namespace WAWSDeploy
             {
                 WriteLine(@"Syntax 1: WAWSDeploy.exe c:\SomeFolder MySite.PublishSettings [/p password]");
                 WriteLine(@"Syntax 2: WAWSDeploy.exe c:\SomeFile.zip MySite.PublishSettings [/p password]");
+                WriteLine(@"Syntax 3: WAWSDeploy.exe c:\SomeFile.zip MySite.PublishSettings [/au]");
                 return;
             }
 
@@ -22,7 +23,7 @@ namespace WAWSDeploy
             {
                 var webDeployHelper = new WebDeployHelper();
                 WriteLine("Starting deployment...");
-                DeploymentChangeSummary changeSummary = webDeployHelper.DeployContentToOneSite(command.Folder, command.PublishSettingsFile, command.Password);
+                DeploymentChangeSummary changeSummary = webDeployHelper.DeployContentToOneSite(command.Folder, command.PublishSettingsFile, command.Password, command.AllowUntrusted);
 
                 WriteLine("BytesCopied: {0}", changeSummary.BytesCopied);
                 WriteLine("Added: {0}", changeSummary.ObjectsAdded);

--- a/WAWSDeploy/WebDeployHelper.cs
+++ b/WAWSDeploy/WebDeployHelper.cs
@@ -15,14 +15,15 @@ namespace WAWSDeploy
         /// <param name="contentPath">The content path.</param>
         /// <param name="publishSettingsFile">The publish settings file.</param>
         /// <param name="password">The password.</param>
+        /// <param name="allowUntrusted">Deploy even if destination certificate is untrusted</param>
         /// <returns>DeploymentChangeSummary.</returns>
-        public DeploymentChangeSummary DeployContentToOneSite(string contentPath, string publishSettingsFile, string password = null)
+        public DeploymentChangeSummary DeployContentToOneSite(string contentPath, string publishSettingsFile, string password = null, bool allowUntrusted = false)
         {
             contentPath = Path.GetFullPath(contentPath);
 
             var sourceBaseOptions = new DeploymentBaseOptions();
             DeploymentBaseOptions destBaseOptions;
-            string siteName = SetBaseOptions(publishSettingsFile, out destBaseOptions);
+            string siteName = SetBaseOptions(publishSettingsFile, out destBaseOptions, allowUntrusted);
 
             // use the password from the command line args if provided
             if (!string.IsNullOrEmpty(password))
@@ -47,7 +48,7 @@ namespace WAWSDeploy
             }
         }
 
-        private string SetBaseOptions(string publishSettingsPath, out DeploymentBaseOptions deploymentBaseOptions)
+        private string SetBaseOptions(string publishSettingsPath, out DeploymentBaseOptions deploymentBaseOptions, bool allowUntrusted)
         {
             PublishSettings publishSettings = new PublishSettings(publishSettingsPath);
             deploymentBaseOptions = new DeploymentBaseOptions
@@ -58,7 +59,7 @@ namespace WAWSDeploy
                 AuthenticationType = publishSettings.UseNTLM ? "ntlm" : "basic",
             };
 
-            if (publishSettings.AllowUntrusted)
+            if (allowUntrusted || publishSettings.AllowUntrusted)
             {
                 ServicePointManager.ServerCertificateValidationCallback = AllowCertificateCallback;
             }


### PR DESCRIPTION
Needed for some test environments. Easier to add this flag than update the publishSettings file
