### PR TITLE
Set the environment "ExitCode" variable to 1 on error.

### DIFF
--- a/WAWSDeploy/Program.cs
+++ b/WAWSDeploy/Program.cs
@@ -49,6 +49,7 @@ namespace WAWSDeploy
             catch (Exception e)
             {
                 WriteLine("Deployment failed: {0}", e.Message);
+                Environment.ExitCode = 1;
             }
         }
 


### PR DESCRIPTION
I know this is a tiny change, but I am trying to use WAWSDeploy in a [Jenkins](http://jenkins-ci.org) job and if the deployment fails right now the [Jenkins](http://jenkins-ci.org) job thinks it was a success. Setting the ExitCode to a non zero value will trigger a fail in [Jenkins](http://jenkins-ci.org). 
