### PR TITLE
Added Ability to Deploy to a Specific Virtual Directory

### DIFF
--- a/WAWSDeploy/DeploymentArgs.cs
+++ b/WAWSDeploy/DeploymentArgs.cs
@@ -45,6 +45,9 @@ namespace WAWSDeploy
         [ArgsMemberSwitch("w", "whatif", "wi")]
         public bool WhatIf { get; set; }
 
+        [ArgsMemberSwitch("s", "sitename", "sn")]
+        public string SiteName { get; set; }
+
         public TraceLevel TraceLevel
         {
             get
@@ -55,6 +58,5 @@ namespace WAWSDeploy
                 return System.Diagnostics.TraceLevel.Off;
             }
         }
-
     }
 }

--- a/WAWSDeploy/Program.cs
+++ b/WAWSDeploy/Program.cs
@@ -18,6 +18,7 @@ namespace WAWSDeploy
                 WriteLine(@" /au /AllowUntrusted: skip cert verification");
                 WriteLine(@" /v  /Verbose: Verbose mode");
                 WriteLine(@" /w  /WhatIf: don't actually perform the publishing");
+                WriteLine(@" /s  /SiteName: the name of a virtual directory to deploy to");
                 return;
             }
 
@@ -39,8 +40,8 @@ namespace WAWSDeploy
                     command.AllowUntrusted,
                     !command.DeleteExistingFiles,
                     command.TraceLevel,
-                    command.WhatIf
-
+                    command.WhatIf,
+                    command.SiteName
                     );
 
                 WriteLine("BytesCopied: {0}", changeSummary.BytesCopied);


### PR DESCRIPTION
Added a command line argument to allow targeted deployment to a specific virtual directory. The new argument is /s or /SiteName followed by the name of the virtual directory to deploy to. This supports the scenario where a single web role is hosting multiple virtual applications, such as a web site and its corresponding API.

Example Usage:
.\WAWSDeploy.exe "_PublishedWebsites\Subdirectory" "mysite.azurewebsites.net.PublishSettings" /s "API"
