### PR TITLE
Add support for physical target path (using 'dirPath' provider)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Target Path - The virtual directory to deploy to
 	
     WAWSDeploy C:\somefolder mysite.PublisSettings /t someVirtualDirectoryName
 
+Target Path - Using a physical target folder
+
+    WAWSDeploy C:\somefolder mysite.PublisSettings /t d:\home\site\blah
+
 
     
 

--- a/WAWSDeploy/Program.cs
+++ b/WAWSDeploy/Program.cs
@@ -18,7 +18,7 @@ namespace WAWSDeploy
                 WriteLine(@" /au /AllowUntrusted: skip cert verification");
                 WriteLine(@" /v  /Verbose: Verbose mode");
                 WriteLine(@" /w  /WhatIf: don't actually perform the publishing");
-                WriteLine(@" /t  /TargetPath: the virtual directory to deploy to");
+                WriteLine(@" /t  /TargetPath: the virtual or physical directory to deploy to");
                 return;
             }
 

--- a/WAWSDeploy/Properties/AssemblyInfo.cs
+++ b/WAWSDeploy/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.0.0")]
-[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyVersion("1.6.0.0")]
+[assembly: AssemblyFileVersion("1.6.0.0")]

--- a/WAWSDeploy/WAWSDeploy.nuspec
+++ b/WAWSDeploy/WAWSDeploy.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>WAWSDeploy</id>
     <title>WAWSDeploy</title>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <authors>David Ebbo</authors>
     <summary>A simple tool to publish a folder to an Azure Web Site</summary>
     <description>A simple tool to publish a folder to an Azure Web Site</description>


### PR DESCRIPTION
It works well, but I couldn't make it work with a source zip Package and target physical. It fails with:

    Source (contentPath) and destination (dirPath) are not compatible for the given operation

Even though my source is really Packaged and not ContentPath. Oh well, it's still useful.