### PR TITLE
Add parameter to enable the AppOffline rule

### DIFF
--- a/WAWSDeploy/DeploymentArgs.cs
+++ b/WAWSDeploy/DeploymentArgs.cs
@@ -51,6 +51,9 @@ namespace WAWSDeploy
         [ArgsMemberSwitch("c", "usechecksum", "cs")]
         public bool UseChecksum { get; set; }
 
+        [ArgsMemberSwitch("o", "appoffline", "off")]
+        public bool AppOffline { get; set; }
+
         public TraceLevel TraceLevel
         {
             get

--- a/WAWSDeploy/Program.cs
+++ b/WAWSDeploy/Program.cs
@@ -20,6 +20,7 @@ namespace WAWSDeploy
                 WriteLine(@" /w  /WhatIf: don't actually perform the publishing");
                 WriteLine(@" /t  /TargetPath: the virtual or physical directory to deploy to");
                 WriteLine(@" /c  /cs: use checksum");
+                WriteLine(@" /o  /AppOffline: automatically take an ASP.Net application offline before publishing to it.");
                 return;
             }
 
@@ -43,7 +44,8 @@ namespace WAWSDeploy
                     command.TraceLevel,
                     command.WhatIf,
                     command.TargetPath,
-                    command.UseChecksum
+                    command.UseChecksum,
+                    command.AppOffline
                     );
 
                 WriteLine("BytesCopied: {0}", changeSummary.BytesCopied);

--- a/WAWSDeploy/WebDeployHelper.cs
+++ b/WAWSDeploy/WebDeployHelper.cs
@@ -29,7 +29,8 @@ namespace WAWSDeploy
             TraceLevel traceLevel = TraceLevel.Off,
             bool whatIf = false,
             string targetPath = null,
-            bool useChecksum = false)
+            bool useChecksum = false,
+            bool appOfflineEnabled = false)
         {
             sourcePath = Path.GetFullPath(sourcePath);
 
@@ -84,13 +85,24 @@ namespace WAWSDeploy
                 WhatIf = whatIf,
                 UseChecksum = useChecksum
             };
-
+            if (appOfflineEnabled) AddDeploymentRule(syncOptions, "AppOffline");
+            
             // Publish the content to the remote site
             using (var deploymentObject = DeploymentManager.CreateObject(sourceProvider, sourcePath, sourceBaseOptions))
             {
                 // Note: would be nice to have an async flavor of this API...
 
                 return deploymentObject.SyncTo(targetProvider, destinationPath, destBaseOptions, syncOptions);
+            }
+        }
+
+        private void AddDeploymentRule(DeploymentSyncOptions syncOptions, string name)
+        {
+            DeploymentRule newRule;
+            var rules = DeploymentSyncOptions.GetAvailableRules();
+            if (rules.TryGetValue(name, out newRule))
+            {
+                syncOptions.Rules.Add(newRule);
             }
         }
 


### PR DESCRIPTION
The rule automatically take an ASP.Net application offline before publishing to it. This is useful if a user wants to ensure that their application does not have a lock on a file.