### PR TITLE
 Add the possibility to skip app_data or other folders during deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ Setup the interval (in milliseconds) between each deployment attempts in case of
 WAWSDeploy C:\somefolder mysite.Publishsettings /i 6000
 ```
 
+Skip the app_data directory during the deployment.
+```PowerShell
+WAWSDeploy C:\somefolder mysite.PublishSettings /sa
+```
+
+User defined folders regular expressions that should be skipped during deployment.
+```PowerShell
+WAWSDeploy C:\somefolder mysite.PublishSettings /sf .*my_tools .*local_cache
+```
+
+
 
 ## To build this project
 

--- a/WAWSDeploy/DeploymentArgs.cs
+++ b/WAWSDeploy/DeploymentArgs.cs
@@ -1,5 +1,4 @@
 ﻿using Args;
-using Args.Help;
 using System.ComponentModel;
 using System.Diagnostics;
 
@@ -77,9 +76,9 @@ namespace WAWSDeploy
             get
             {
                 if (Verbose)
-                    return System.Diagnostics.TraceLevel.Verbose;
+                    return TraceLevel.Verbose;
 
-                return System.Diagnostics.TraceLevel.Off;
+                return TraceLevel.Off;
             }
         }
     }

--- a/WAWSDeploy/DeploymentArgs.cs
+++ b/WAWSDeploy/DeploymentArgs.cs
@@ -1,4 +1,5 @@
-﻿using Args;
+﻿using System.Collections.Generic;
+using Args;
 using System.ComponentModel;
 using System.Diagnostics;
 
@@ -28,7 +29,7 @@ namespace WAWSDeploy
         /// </summary>
         /// <value>The password.</value>
         [ArgsMemberSwitch("p", "password", "pw"),
-            Description("provide the password if it's not in the profile (default: use from the publish settings).")]
+         Description("provide the password if it's not in the profile (default: use from the publish settings).")]
         public string Password { get; set; }
 
         /// <summary>
@@ -36,40 +37,50 @@ namespace WAWSDeploy
         /// </summary>
         /// <value>true or false</value>
         [ArgsMemberSwitch("u", "allowuntrusted", "au"),
-            Description("skip cert verification (default: false).")]
+         Description("skip cert verification (default: false).")]
         public bool AllowUntrusted { get; set; }
 
         [ArgsMemberSwitch("d", "deleteexistingfiles", "def"),
-            Description("delete target files that don't exist at the source (default: false).")]
+         Description("delete target files that don't exist at the source (default: false).")]
         public bool DeleteExistingFiles { get; set; }
 
         [ArgsMemberSwitch("v", "verbose", "vb"),
-            Description("Verbose mode (default: false)")]
+         Description("Verbose mode (default: false)")]
         public bool Verbose { get; set; }
 
         [ArgsMemberSwitch("w", "whatif", "wi"),
-            Description("don't actually perform the publishing (default: false).")]
+         Description("don't actually perform the publishing (default: false).")]
         public bool WhatIf { get; set; }
 
         [ArgsMemberSwitch("t", "targetpath", "tp"),
-            Description("the virtual or physical directory to deploy to.")]
+         Description("the virtual or physical directory to deploy to.")]
         public string TargetPath { get; set; }
 
         [ArgsMemberSwitch("c", "usechecksum", "cs"),
-            Description("use checksum (default: false).")]
+         Description("use checksum (default: false).")]
         public bool UseChecksum { get; set; }
 
         [ArgsMemberSwitch("o", "appoffline", "off"),
-            Description("attempt to automatically take an ASP.Net application offline before publishing to it (default: false).")]
+         Description(
+             "attempt to automatically take an ASP.Net application offline before publishing to it (default: false).")]
         public bool AppOffline { get; set; }
 
-        [ArgsMemberSwitch("r", "retryattempts", "ra"), 
-            Description("number of deployment retry attempts in case of failure (default: 5).")]
+        [ArgsMemberSwitch("r", "retryattempts", "ra"),
+         Description("number of deployment retry attempts in case of failure (default: 5).")]
         public int? RetryAttempts { get; set; }
 
         [ArgsMemberSwitch("i", "retryinterval", "ri"),
-            Description("retry interval in ms between attempts in case of failure (default: 1000).")]
+         Description("retry interval in ms between attempts in case of failure (default: 1000).")]
         public int? RetryInterval { get; set; }
+
+        [ArgsMemberSwitch("a", "skipappdata", "sa"),
+         Description("Skip the application data during the deployment... (default: false).")]
+        public bool SkipAppData { get; set; }
+
+        [ArgsMemberSwitch("s", "skipfoldersregexps", "sf"),
+         Description(
+             "Skip the folders matching the given regular expressions during the deployment... (default: null).")]
+        public IEnumerable<string> SkipFoldersRegexps { get; set; }
 
         public TraceLevel TraceLevel
         {

--- a/WAWSDeploy/Program.cs
+++ b/WAWSDeploy/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Args.Help;
 using Args.Help.Formatters;
 using Microsoft.Web.Deployment;
@@ -27,7 +28,6 @@ namespace WAWSDeploy
 
                 webDeployHelper.DeploymentTraceEventHandler += Trace;
 
-
                 WriteLine("Starting deployment...");
                 DeploymentChangeSummary changeSummary = webDeployHelper.DeployContentToOneSite(
                     command.Folder, 
@@ -41,7 +41,9 @@ namespace WAWSDeploy
                     command.UseChecksum,
                     command.AppOffline,
                     command.RetryAttempts,
-                    command.RetryInterval
+                    command.RetryInterval,
+                    command.SkipAppData,
+                    command.SkipFoldersRegexps
                     );
 
                 WriteLine("BytesCopied: {0}", changeSummary.BytesCopied);


### PR DESCRIPTION
Introduce the /sa switch to skip the app_data folder during deployment.
Introduce the /sf switch to allow passing regular expressions of
folders that should be skipped during deployment.

This should cover davidebbo/WAWSDeploy#16